### PR TITLE
Return promise; No Catch Block; Better message;

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,14 +4,11 @@ var WriteData = require('./write-data');
 var main = function(options) {
   console.log("Gathering Manifest data...");
   var options = {decrypt: options.decrypt, basedir: options.output, uri: options.input};
-  WalkManifest(options)
+  return WalkManifest(options)
     .then(function(resources) {
       console.log("Downloading additional data...");
       return WriteData(options.decrypt, options.concurrency, resources);
     })
-    .catch(function(err) {
-      throw err;
-    });
 };
 
 module.exports = main;

--- a/src/walk-manifest.js
+++ b/src/walk-manifest.js
@@ -162,9 +162,7 @@ var walkPlaylist = function(options) {
     }
 
     if (visitedUrls.includes(manifest.uri)) {
-      var manifestError = new Error('[WARN] Trying to visit the same uri again; skipping to avoid getting stuck in a cycle');
-      manifestError.uri = manifest.uri;
-      console.error(manifestError);
+      console.error(`[WARN] Trying to visit the same uri again; skipping to avoid getting stuck in a cycle: ${manifest.uri}`);
       return resolve(resources);
     }
 


### PR DESCRIPTION
https://github.com/videojs/hls-fetcher/pull/22
We can't skip the keyError since we need the `onError` to fire for it and the error messages are different; unless I missed something.

@gkatsev @mwhipple