### PR TITLE
Remove videojs-errors description from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@
 
 [![NPM](https://nodei.co/npm/hls-fetcher.png?downloads=true&downloadRank=true)](https://nodei.co/npm/hls-fetcher/)
 
-A plugin that displays user-friendly messages when Video.js encounters an error.
-
 Maintenance Status: Stable
 
 A simple CLI tool to fetch an entire hls manifest and it's segments and save it all locally.


### PR DESCRIPTION
This is not part of this project.
> A plugin that displays user-friendly messages when Video.js encounters an error.